### PR TITLE
fix: Add quotes to handle undefined variable.

### DIFF
--- a/docker/pbrun-fq2bam.sh
+++ b/docker/pbrun-fq2bam.sh
@@ -56,7 +56,7 @@ for i in `seq 1 ${#KNOWNS[*]}` ; do
     infq="$infq --knownSites ${KNOWNS[i-1]}"
 done
 
-if [ $KNOWN_SITES != "" ] ; then
+if [ "$KNOWN_SITES" != "" ] ; then
     echo "
     pbrun fq2bam \
 	--ref ${REF} \


### PR DESCRIPTION
In Tutorial 1 and 2, when KNOWN_SITES is undefined, the following error occurs:
> [: !=: unary operator expected

To avoid this error, I added double quotes around the variable.